### PR TITLE
Fixing the error link address

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Lumina
 
 **English** | [中文](./README_cn.md)
 
-> Fork of [Folia](https://github.com/PaperMC/Paper) aims at repairing broken vanilla properties.
+> Fork of [Folia]](https://github.com/PaperMC/Folia) aims at repairing broken vanilla properties.
 
 This is currently an empty repository, and the priority of this project will not be too high.
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Lumina
 
 **English** | [中文](./README_cn.md)
 
-> Fork of [Folia]](https://github.com/PaperMC/Folia) aims at repairing broken vanilla properties.
+> Fork of [Folia](https://github.com/PaperMC/Folia) aims at repairing broken vanilla properties.
 
 This is currently an empty repository, and the priority of this project will not be too high.
 


### PR DESCRIPTION
The link of folia inside [README.md](https://github.com/LeavesMC/Lumina/blob/master/README.md) has been set to link of paper, which should be a mistake