### PR TITLE
fix: Sync the Chinese README file name changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Lumina
 [![Discord](https://badgen.net/discord/online-members/5hgtU72w33?icon=discord&label=Discord&list=what)](https://discord.gg/5hgtU72w33)
 [![QQ](https://img.shields.io/badge/QQ-815857713-blue)](http://qm.qq.com/cgi-bin/qm/qr?_wv=1027&k=nisbmnCFeEJCcYWBQ10th4Fu99XWklH4&authKey=8VlUxSdrFCIwmIpxFQIGR8%2BXvIQ2II%2Bx2JfxuQ8amr9UKgINh%2BdXjudQfc%2FIeTO5&noverify=0&group_code=815857713)
 
-**English** | [中文](./README_cn.md)
+**English** | [中文](./README_ZH.md)
 
 > Fork of [Folia](https://github.com/PaperMC/Folia) aims at repairing broken vanilla properties.
 


### PR DESCRIPTION
Corrected an incorrect link in the README file.
This commit only synchronizes the changes to the Chinese README file name.